### PR TITLE
GitHub Actionsでmigrationを実行する処理を追加

### DIFF
--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       - name: Install golang-migrate
         run: |
-          curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | apt-key add -
+          curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | sudo apt-key add -
           echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
-          apt update
-          apt install -y migrate
+          sudo apt update
+          sudo apt install -y migrate
 
       - name: Migrate production database
         run: migrate -path migrations/migrations -database ${{ secrets.DATABASE_URL }} up

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | sudo apt-key add -
           echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/migrate.list
-          sudo apt update
-          sudo apt install -y migrate
+          sudo apt-get update
+          sudo apt-get install -y migrate
 
       - name: Migrate production database
         run: migrate -path migrations/migrations -database ${{ secrets.DATABASE_URL }} up

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install golang-migrate
         run: |
           curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | sudo apt-key add -
-          echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
+          sudo echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
           sudo apt update
           sudo apt install -y migrate
 

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -29,12 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: database
     steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.2
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install golang-migrate
-        run: |
-          curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | sudo apt-key add -
-          echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/migrate.list
-          sudo apt-get update
-          sudo apt-get install -y migrate
+        run: go install -tags 'mysql' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
       - name: Migrate production database
         run: migrate -path migrations/migrations -database ${{ secrets.DATABASE_URL }} up

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -26,6 +26,7 @@ jobs:
 
   migrate:
     name: DB migration
+    needs: build
     runs-on: ubuntu-latest
     environment: database
     steps:
@@ -62,7 +63,7 @@ jobs:
 
   push_to_registry:
     name: Push Docker image to Docker Hub
-    needs: build
+    needs: migrate
     runs-on: ubuntu-latest
     environment: dockerhub
     steps:

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -55,6 +55,11 @@ jobs:
           database_url: ${{ secrets.DATABASE_URL }}
         run: migrate -path migrations/migrations -database "$database_url" up
 
+      - name: Remove trusted source
+        run: |
+          UUID=$(doctl database firewalls list ${{ secrets.DIGITALOCEAN_DATABASE_ID }} | grep $(curl -s https://checkip.amazonaws.com/) | awk '{print $1}')
+          doctl databases firewalls remove ${{ secrets.DIGITALOCEAN_DATABASE_ID }} --uuid ${UUID}
+
   push_to_registry:
     name: Push Docker image to Docker Hub
     needs: build

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -3,7 +3,7 @@ name: Build and publish Docker image
 on:
   push:
     branches:
-      - main
+      - test_ci_migrate
 
 jobs:
   build:
@@ -23,6 +23,21 @@ jobs:
 
       - name: Build
         run: go build -v cmd/api
+
+  migrate:
+    name: DB migration
+    runs-on: ubuntu-latest
+    environment: database
+    steps:
+      - name: Install golang-migrate
+        run: |
+          curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | apt-key add -
+          echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
+          apt update
+          apt install -y migrate
+
+      - name: Migrate production database
+        run: migrate -path migrations/migrations -database ${{ secrets.DATABASE_URL }} up
 
   push_to_registry:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -3,7 +3,7 @@ name: Build and publish Docker image
 on:
   push:
     branches:
-      - test_ci_migrate
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -37,8 +37,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
       - name: Install golang-migrate
         run: go install -tags 'mysql' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+      - name: Add trusted source
+        run: |
+          IP=$(curl -s https://checkip.amazonaws.com/)
+          doctl databases firewalls append ${{ secrets.DIGITALOCEAN_DATABASE_ID }} --rule ip_addr:"${IP}"
 
       - name: Migrate production database
         env:

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install golang-migrate
         run: |
           curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | sudo apt-key add -
-          sudo echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
+          echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/migrate.list
           sudo apt update
           sudo apt install -y migrate
 

--- a/.github/workflows/build_and_publish_docker_image.yml
+++ b/.github/workflows/build_and_publish_docker_image.yml
@@ -41,7 +41,9 @@ jobs:
         run: go install -tags 'mysql' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
       - name: Migrate production database
-        run: migrate -path migrations/migrations -database ${{ secrets.DATABASE_URL }} up
+        env:
+          database_url: ${{ secrets.DATABASE_URL }}
+        run: migrate -path migrations/migrations -database "$database_url" up
 
   push_to_registry:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
## 実施事項
- mainブランチへのマージ時のGitHub Actionsワークフローにおいて、migrationを行う処理を追加

### 補足
- migrationの実行前に、`Add trusted source`ステップにおいて、DBの接続許可IPにワークフローが実行される仮想マシンのIPを追加している。これを行わないと接続が失敗する。
- migration実行後、`Remove trusted source`ステップにおいて上記で追加したIPを削除している。DBの接続許可IPを削除するには、`doctl databases firewalls remove`コマンドでUUIDを指定する必要がある。`doctl database firewalls list <db_id>`コマンドで下記のように結果が出力されるので、IPの値を元に行を取得した上で、awkコマンドで当該行の1番目の文字列を取得することでUUIDを抽出している。

```
$ doctl database firewalls list <db_id>

UUID                                    ClusterUUID                             Type       Value
xxxxxxxx                                xxxxxxxx                                id_addr    xxx.xxx.xxx.xxx
```